### PR TITLE
Creating teams clears requests. Don't accept team-owners

### DIFF
--- a/backend/src/services/team-service.ts
+++ b/backend/src/services/team-service.ts
@@ -313,7 +313,18 @@ export class TeamService implements ITeamService {
     }
 
     if (!team.requestUserIds().includes(userId)) {
-      throw new Error(`user ${userId} did not request to join team ${teamId}`);
+      throw new Error(`User ${userId} did not request to join team ${teamId}`);
+    }
+
+    const oldTeam = await this._teams.findOne({
+      where: { id: userId },
+      relations: ["users", "requests", "owner"],
+    });
+
+    if (oldTeam?.owner?.id === userId) {
+      throw new Error(
+        "The user needs to select a new owner for their old team first",
+      );
     }
 
     await this._users.update({ id: userId }, { team, teamRequest: null });

--- a/backend/src/services/team-service.ts
+++ b/backend/src/services/team-service.ts
@@ -167,10 +167,6 @@ export class TeamService implements ITeamService {
       throw new Error("Team description cannot be empty");
     }
 
-    // TODO leaving team should make someone else owner
-    // TODO order of team.users not guaranteed anymore I guess,
-    //  - you can only own one team, just like you can only be part of one team
-
     if (user.team) {
       throw new Error("You are already part of a team");
     }
@@ -185,6 +181,7 @@ export class TeamService implements ITeamService {
     const createdTeam = await this._teams.save(team);
 
     user.team = createdTeam;
+    user.teamRequest = null;
     await this._users.save(user);
 
     // Every team gets one project by default

--- a/backend/test/services/team-service.spec.ts
+++ b/backend/test/services/team-service.spec.ts
@@ -121,7 +121,7 @@ describe("TeamService", () => {
   });
 
   describe("acceptUserToTeam", () => {
-    it("throws when the requester is neither owner nor admin", async () => {
+    it("throws when the accepting user is neither owner nor admin", async () => {
       expect.assertions(1);
 
       const owner = await userRepo.save(makeUser("owner@test.com"));
@@ -139,6 +139,24 @@ describe("TeamService", () => {
           randomUser,
         ),
       ).rejects.toThrow("You are not the owner of this team");
+    });
+
+    it("throws when the requester is owner of another team", async () => {
+      expect.assertions(1);
+
+      const team1Owner = await userRepo.save(makeUser("owner@test.com"));
+      const team1 = await teamService.createTeam(makeTeam(), team1Owner);
+
+      const team2Owner = await userRepo.save(makeUser("req@test.com"));
+      const team2 = await teamService.createTeam(makeTeam(), team2Owner);
+
+      await userRepo.save({ ...team2Owner, team: team2, teamRequest: team1 });
+
+      await expect(
+        teamService.acceptUserToTeam(team1.id, team2Owner.id, team1Owner),
+      ).rejects.toThrow(
+        "The user needs to select a new owner for their old team first",
+      );
     });
 
     it("allows the team owner to accept a join request", async () => {

--- a/backend/test/services/team-service.spec.ts
+++ b/backend/test/services/team-service.spec.ts
@@ -77,6 +77,21 @@ describe("TeamService", () => {
       expect(foundTeam!.owner.id).toEqual(user.id);
     });
 
+    it("clears the users team request", async () => {
+      expect.assertions(1);
+
+      const team = await teamRepo.save(makeTeam("Team 1"));
+
+      const user = await userRepo.save({
+        ...makeUser("member@test.com"),
+        teamRequest: team,
+      });
+      await teamService.createTeam(makeTeam(), user);
+
+      const updatedUser = await userRepo.findOne({ where: { id: user.id } });
+      expect(updatedUser!.teamRequest).toBeNull();
+    });
+
     it("assigns the newly created team to the user", async () => {
       expect.assertions(1);
 


### PR DESCRIPTION
They'll need to select a new owner for their team first